### PR TITLE
Remove 'renderer' field

### DIFF
--- a/netplan/parser.py
+++ b/netplan/parser.py
@@ -164,7 +164,8 @@ class Parser(object):
                     "Unsupported format version {ver}".format(ver=ver)
                 )
             del net["version"]
-            del net["renderer"]
+            if net.get("renderer", -1) != -1:
+                del net["renderer"]
             missing = sorted(set(net.keys()) - skeys)
             if missing:
                 raise Exception(

--- a/netplan/parser.py
+++ b/netplan/parser.py
@@ -164,6 +164,7 @@ class Parser(object):
                     "Unsupported format version {ver}".format(ver=ver)
                 )
             del net["version"]
+            del net["renderer"]
             missing = sorted(set(net.keys()) - skeys)
             if missing:
                 raise Exception(


### PR DESCRIPTION
This is not required on most setups, and if it is, you'll know you need it.
Removing this field will mean that netplan reverts back to its default renderer which is networkd